### PR TITLE
Boxcars 0.4.1 - edition 2018 - snafu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,16 +81,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "boxcars"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitter 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multimap 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multimap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -195,6 +194,11 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "doc-comment"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "either"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,26 +220,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -334,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -670,13 +654,13 @@ name = "rrrocket"
 version = "0.4.2-pre"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "boxcars 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "boxcars 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -751,6 +735,26 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "snafu"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,17 +798,6 @@ dependencies = [
  "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -901,7 +894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum bitter 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "537bee75263edafe77f511fe21c3427466ecb48bbafe60ce2e938ae5392872ed"
-"checksum boxcars 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0a8238158e6d50f4e861438706b8fc93754fb3a77e47bec18d370789255738f6"
+"checksum boxcars 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "372e9c934d9abf6ecb821a25145d225cf7bdff1c8cc8cd6386376b0c6ba8d41c"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
@@ -914,11 +907,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum escargot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb9adbf9874d5d028b5e4c5739d22b71988252b25c9c98fe7cf9738bee84597"
-"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
-"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "134a8fa843d80a51a5b77d36d42bc2def9edcb0262c914861d08129fd1926600"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
@@ -933,7 +925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
-"checksum multimap 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1838fe05e64c53b9a62579020e4a12ec5947af5d703c56962d0e3b7b923bf3ba"
+"checksum multimap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de234f818d54830a7103b9be18ad0861d75aeb5e3c89759bc3f9a004cc39cfa3"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e0a1a39eab95caf4f5556da9289b9e68f0aafac901b2ce80daaf020d3b733a8"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
@@ -982,12 +974,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d0bf93d08d6a44363b47d737f1f5bebbf5e6a1eaaa3d4c128ceeaca6b718292"
+"checksum snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624e94bd38e471f67883b467711e7a7ad7dbe284f5fb7e661dc8a671fc5b26a0"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48399718b3ad695558b979b08a9056a5272ec573cd3070f5ca34165bd4a5bf35"
 "checksum structopt-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2558075232402034384db060831349fb2d1303479593177cc84c25febbebbc6d"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
-"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ description = "Rocket League Replay parser to JSON CLI app"
 edition = "2018"
 
 [dependencies]
-failure = "0.1.5"
+snafu = "0.5.0"
 serde_json = "1"
 structopt = "0.3"
 rayon = "1"
-boxcars = "0.3.5"
+boxcars = "0.4.1"
 globset = "0.4"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/nickbabcock/boxcars"
 version = "0.4.2-pre"
 publish = false
 description = "Rocket League Replay parser to JSON CLI app"
+edition = "2018"
 
 [dependencies]
 failure = "0.1.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,40 @@
-use boxcars::{CrcCheck, NetworkParse, ParserBuilder, Replay};
-use failure::{err_msg, Error, ResultExt};
+use boxcars::{CrcCheck, NetworkParse, ParserBuilder, Replay, ParseError};
 use globset::Glob;
 use rayon::prelude::*;
-use std::fs::{File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
 use std::io::{self, BufWriter};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use structopt::StructOpt;
+use snafu::{Snafu, ResultExt, ErrorCompat};
+
+#[derive(Debug, Snafu)]
+enum RocketError {
+    #[snafu(display("Unable to read replay from {}: {}", path.display(), source))]
+    ReadReplay { source: io::Error, path: PathBuf },
+
+    #[snafu(display("Unable to read directory for replays {}: {}", path.display(), source))]
+    ReadDir { source: io::Error, path: PathBuf },
+
+    #[snafu(display("Unable to parse replay {}: {}", path.display(), source))]
+    ParseReplay {
+        #[snafu(source(from(ParseError, Box::new)))]
+        source: Box<ParseError>,
+        path: PathBuf
+    },
+
+    #[snafu(display("Could not open json output file {}: {}", path.display(), source))]
+    OpenOutput { source: io::Error, path: PathBuf },
+
+    #[snafu(display("Could not serialize replay {}: {}", path.display(), source))]
+    JsonSerialization { source: serde_json::Error, path: PathBuf },
+
+    #[snafu(display("Expected one input file --multiple is not specified"))]
+    InputArguments,
+
+    #[snafu(display("Could not read stdin: {}", source))]
+    ReadStdin { source: io::Error }
+}
 
 #[derive(StructOpt, Debug, Clone, PartialEq)]
 #[structopt(
@@ -49,16 +77,11 @@ struct Opt {
     input: Vec<String>,
 }
 
-fn read_file(input: &str) -> Result<Vec<u8>, Error> {
-    let mut f = File::open(input)
-        .with_context(|_e| format!("Could not open rocket league file: {}", input))?;
-    let mut buffer = vec![];
-    f.read_to_end(&mut buffer)
-        .with_context(|_e| format!("Could not read rocket league file: {}", input))?;
-    Ok(buffer)
+fn read_file(input: &str) -> Result<Vec<u8>, RocketError> {
+    fs::read(input).context(ReadReplay { path: input })
 }
 
-fn parse_replay<'a>(opt: &Opt, data: &'a [u8]) -> Result<Replay<'a>, Error> {
+fn parse_replay<'a>(opt: &Opt, data: &'a [u8]) -> Result<Replay<'a>, ParseError> {
     ParserBuilder::new(&data[..])
         .with_crc_check(if opt.crc {
             CrcCheck::Always
@@ -75,8 +98,8 @@ fn parse_replay<'a>(opt: &Opt, data: &'a [u8]) -> Result<Replay<'a>, Error> {
 
 /// Each file argument that we get could be a directory so we need to expand that directory and
 /// find all the *.replay files. File arguments turn into single element vectors.
-fn expand_paths(files: &[String]) -> Result<Vec<Vec<String>>, Error> {
-    let glob = Glob::new("*.replay")?.compile_matcher();
+fn expand_paths(files: &[String]) -> Result<Vec<Vec<String>>, RocketError> {
+    let glob = Glob::new("*.replay").unwrap().compile_matcher();
 
     files
         .iter()
@@ -89,7 +112,8 @@ fn expand_paths(files: &[String]) -> Result<Vec<Vec<String>>, Error> {
                 // the future, we could get smart and ignore directories / files we don't have
                 // permission that wouldn't match the pattern anyways
                 let files: Result<Vec<_>, _> = p
-                    .read_dir()?
+                    .read_dir()
+                    .context(ReadDir { path: p })?
                     .filter_map(|entry| {
                         match entry {
                             Ok(y) => {
@@ -103,7 +127,7 @@ fn expand_paths(files: &[String]) -> Result<Vec<Vec<String>>, Error> {
                                     None
                                 }
                             }
-                            Err(e) => Some(Err(e)),
+                            Err(e) => Some(Err(RocketError::ReadReplay { source: e, path: p.to_path_buf() }))
                         }
                     })
                     .collect();
@@ -115,16 +139,15 @@ fn expand_paths(files: &[String]) -> Result<Vec<Vec<String>>, Error> {
         .collect()
 }
 
-fn parse_multiple_replays(opt: &Opt) -> Result<(), Error> {
-    let res: Result<Vec<()>, Error> = expand_paths(&opt.input)?
+fn parse_multiple_replays(opt: &Opt) -> Result<(), RocketError> {
+    let res: Result<Vec<()>, RocketError> = expand_paths(&opt.input)?
         .into_iter()
         .flat_map(|x| x)
         .collect::<Vec<_>>()
         .par_iter()
         .map(|file| {
             let data = read_file(file)?;
-            let replay = parse_replay(opt, &data[..])
-                .with_context(|_e| format!("Could not parse: {}", file))?;
+            let replay = parse_replay(opt, &data[..]).context(ParseReplay { path: file })?;
 
             if !opt.dry_run {
                 let outfile = format!("{}.json", file);
@@ -133,11 +156,10 @@ fn parse_multiple_replays(opt: &Opt) -> Result<(), Error> {
                     .create(true)
                     .truncate(true)
                     .open(&outfile)
-                    .with_context(|_e| format!("Could not open json output file: {}", outfile))?;
+                    .context(OpenOutput { path: outfile })?;
 
                 let mut writer = BufWriter::new(fout);
-                serialize(opt, &mut writer, &replay)
-                    .with_context(|_e| format!("Could not serialize replay {}", file))?;
+                serialize(opt, &mut writer, &replay).context(JsonSerialization { path: file })?;
             }
             Ok(())
         })
@@ -154,31 +176,29 @@ fn serialize<W: Write>(opt: &Opt, writer: W, replay: &Replay<'_>) -> Result<(), 
     }
 }
 
-fn run() -> Result<(), Error> {
+fn run() -> Result<(), RocketError> {
     let opt = Opt::from_args();
     if opt.multiple {
         parse_multiple_replays(&opt)
     } else if opt.input.len() > 1 {
-        Err(err_msg(
-            "Expected one input file if --multiple is not specified",
-        ))
+        Err(RocketError::InputArguments)
     } else {
         let data = if opt.input.is_empty() {
             let mut d = Vec::new();
             io::stdin()
                 .read_to_end(&mut d)
-                .context("Could not read stdin")?;
+                .context(ReadStdin)?;
             d
         } else {
             let file = &opt.input[0];
             read_file(file)?
         };
 
-        let replay = parse_replay(&opt, &data[..]).context("Could not parse replay")?;
+        let replay = parse_replay(&opt, &data[..]).context(ParseReplay { path: "stdin" })?;
         if !opt.dry_run {
             let stdout = io::stdout();
             let lock = stdout.lock();
-            serialize(&opt, BufWriter::new(lock), &replay).context("Could not serialize replay")?;
+            serialize(&opt, BufWriter::new(lock), &replay).context(JsonSerialization { path: "stdout" })?;
         }
         Ok(())
     }
@@ -186,9 +206,9 @@ fn run() -> Result<(), Error> {
 
 fn main() {
     if let Err(ref e) = run() {
-        let mut stderr = io::stderr();
-        for fail in e.iter_chain() {
-            let _ = writeln!(stderr, "{}", fail);
+        eprintln!("An error occurred: {}", e);
+        if let Some(backtrace) = ErrorCompat::backtrace(&e) {
+            eprintln!("{}", backtrace);
         }
 
         ::std::process::exit(1);
@@ -216,7 +236,7 @@ mod tests {
             .failure()
             .code(1)
             .stderr(predicate::str::contains(
-                "Could not open rocket league file: non-exist/assets/fuzz-string-too-long.replay",
+                "Unable to read replay from non-exist/assets/fuzz-string-too-long.replay",
             ));
     }
 
@@ -235,7 +255,7 @@ mod tests {
             .failure()
             .code(1)
             .stderr(predicate::str::contains(
-                "Could not parse: assets/fuzz-string-too-long.replay",
+                "Unable to parse replay assets/fuzz-string-too-long.replay",
             ))
             .stderr(predicate::str::contains(
                 "Crc mismatch. Expected 3765941959 but received 1825689991",


### PR DESCRIPTION
- Update to boxcars 0.4.1 which can parse v1.66 replays and includes
attribute object ids in the serialized json output
- Since boxcars removed failure as a dependency, I've decided to test
out snafu in rrrocket.
- Bump the code to Rust 2018 edition