### PR TITLE
Bump boxcars to 0.9.16 for preliminary v2.45 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ checksum = "ef3a13b71496a92e8c00ebe576b260655b56935cd5118d5a8949788b651b5e07"
 
 [[package]]
 name = "boxcars"
-version = "0.9.15"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a309304cafdffd15884545e0c5eab68a1fbe9fbc00584c749d70ad1030fc3bb"
+checksum = "3e47bea450876df722df90f8fd246606290440377c819527c5d88c3f76d2b71d"
 dependencies = [
  "bitter",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 rayon = "1"
-boxcars = "0.9.14"
+boxcars = "0.9.16"
 glob = "0.3"
 either = "1"
 memmap2 = "0.9.5"


### PR DESCRIPTION
Close #267 