### PR TITLE
Avoid musl's default allocator due to perf issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libz-ng-sys"
 version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -619,6 +638,7 @@ dependencies = [
  "fs_extra",
  "glob",
  "memmap2",
+ "mimalloc",
  "predicates",
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ memmap2 = "0.9.5"
 # https://github.com/zip-rs/zip2/pull/247#issuecomment-2541464228
 zip = { version = "=2.1.3", default-features = false, features = ["deflate-zlib-ng"] }
 
+[target.'cfg(target_env = "musl")'.dependencies]
+mimalloc = "0.1.43"
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,11 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, sync_channel};
 use std::thread;
 
+// Avoid musl's default allocator due to terrible performance
+#[cfg(target_env = "musl")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Parses Rocket League replay files and outputs JSON with decoded information
 #[derive(Parser, Debug, Clone, PartialEq)]
 struct Opt {


### PR DESCRIPTION
This nets a 6x performance win.