### PR TITLE
Swap out zip crc to impl with hardware intrinsics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-clap = { version = "4.5.53", features = ["derive"] }
-rayon = "1.11.0"
 boxcars = "0.10.10"
+clap = { version = "4.5.53", features = ["derive"] }
 glob = "0.3.3"
+libdeflater = "1.25.0"
 memmap2 = "0.9.9"
 rawzip = "0.4.3"
-libdeflater = "1.25.0"
+rayon = "1.11.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [target.'cfg(target_env = "musl")'.dependencies]
 mimalloc = "0.1.48"

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,7 +341,7 @@ fn zip(file_path: &Path, opt: &Opt) -> anyhow::Result<()> {
                 let inflation = decompressor.deflate_decompress(&raw, inflated)?;
                 let _ = return_buf.send(raw);
 
-                let crc = rawzip::crc32(&inflated[..inflation]);
+                let crc = libdeflater::crc32(&inflated[..inflation]);
                 verification.valid(rawzip::ZipVerification {
                     crc,
                     uncompressed_size: inflation as u64,


### PR DESCRIPTION
Parses 10000 replays about 5% faster

And sorts the cargo dependencies